### PR TITLE
Improve reusability

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,16 @@ You either have to define a 'prefix' or a 'pattern' and 'replaceExp'. All other 
     (default: `['dependencies', 'devDependencies']`)  
     which keys in config object contain packages to require
 
+  - `module`
+    (default: the module that executed `require('auto-plug')`)
+    The module used to find the default `config` and `requireFn` options
+    
   - `config`  
-    (default: current package's package.json data)  
+    (default: `module`'s package.json data)  
     the config where auto-plug will look for packages to require; can be a plain object or a string containing a path to require
 
   - `requireFn`  
-    (default: current package's `require`)  
+    (default: `module.require`)  
     the function to be used for requiring packages
 
   - `camelize`  
@@ -146,8 +150,9 @@ You either have to define a 'prefix' or a 'pattern' and 'replaceExp'. All other 
     pattern: [prefix + '-*', prefix + '.*'],
     replaceExpr: new RegExp('^' + prefix + '(-|\\.)'),
     scope: ['dependencies', 'devDependencies'],
-    config: findup('package.json', {cwd: parentDir}),
-    requireFn: require,
+    module: module.parent, // the module that require()'d auto-plug
+    config: findup('package.json', {cwd: path.dirname(module.filename)}),
+    requireFn: module.require.bind(module),
     camelize: true,
     lazy: true,
     rename: {}

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You either have to define a 'prefix' or a 'pattern' and 'replaceExp'. All other 
     the config where auto-plug will look for packages to require; can be a plain object or a string containing a path to require
 
   - `requireFn`  
-    (default: `require`)  
+    (default: current package's `require`)  
     the function to be used for requiring packages
 
   - `camelize`  

--- a/fixtures/auto-plug.js
+++ b/fixtures/auto-plug.js
@@ -2,4 +2,4 @@
    require() instead of the test moudle's require() */
 
 module.exports = require('..');
-
+module.exports.module = module;

--- a/fixtures/auto-plug.js
+++ b/fixtures/auto-plug.js
@@ -1,0 +1,5 @@
+/* This just exports auto-plug, but a version that uses this module's
+   require() instead of the test moudle's require() */
+
+module.exports = require('..');
+

--- a/fixtures/package.json
+++ b/fixtures/package.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": {"jack-foo": "*"}
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,6 +116,7 @@ AutoPlug.prototype.addPackageToContainer = function(pkgName) {
     var requireName = this.getRequireNameForPackage(pkgName);
     if (this.options.lazy) {
         Object.defineProperty(this.container, requireName, {
+            enumerable: true,
             get: function() {
                 return this.options.requireFn(pkgName);
             }.bind(this)

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,13 +6,6 @@ var multimatch = require('multimatch'),
 
 
 /**
- * parent module's directory to find package.json
- * @type {String}
- */
-var parentDir = path.dirname(module.parent.filename);
-
-
-/**
  * AutoPlug Class
  *
  * @param {mixed} options  custom options object or options.prefix string
@@ -37,9 +30,13 @@ AutoPlug.prototype.optionsProperties = {
         type: 'String',
         arrayify: true
     },
+    module: {
+        default: module.parent,
+        type: 'Object'
+    },
     requireFn: {
         getDefault: function() {
-            return module.parent.require.bind(module.parent);
+            return this.options.module.require.bind(this.options.module);
         },
         type: 'Function'
     },
@@ -74,7 +71,10 @@ AutoPlug.prototype.optionsProperties = {
     config: {
         type: ['String', 'Object'],
         getDefault: function() {
-            return findup('package.json', {cwd: parentDir});
+            return findup(
+                'package.json',
+                {cwd: path.dirname(this.options.module.filename)}
+            );
         },
         after: function() {
             this.retrieveAndValidateConfigData();

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,9 @@ AutoPlug.prototype.optionsProperties = {
         arrayify: true
     },
     requireFn: {
-        default: require,
+        getDefault: function() {
+            return module.parent.require.bind(module.parent);
+        },
         type: 'Function'
     },
     camelize: {

--- a/test/index.js
+++ b/test/index.js
@@ -27,7 +27,9 @@ var autoPlug = (function() {
 describe('auto-plug', function() {
 
     it('should find parent package\'s package.json and return a plain object', function() {
-        assert({}, require('..')('bob'));
+        assert.deepEqual(
+            {sync:require('findup-sync')}, require('..')('findup')
+        );
     });
 
     it('should throw an error if it can\'t find a package.json', function() {
@@ -83,6 +85,9 @@ var commonTests = function(lazy) {
             }
         });
 
+        assert.deepEqual(
+            Object.keys(ap), ['foo', 'bar', 'insert', 'baz']
+        );
         assert.deepEqual(ap.foo(), {
             name: 'foo'
         });

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,15 @@ var autoPlug = (function() {
         };
     };
     var proxyquire = require('proxyquire').noCallThru();
-    return proxyquire('..', {
+
+    /* Ensure that our fixture won't be able to findup() */
+    function noFindUp() { return null; }
+    noFindUp['@global'] = true;
+
+    /* Load a dummy module whose require() will have these results,
+       and return an auto-plug function customized for that module
+     */
+    return proxyquire('../fixtures/auto-plug.js', {
             'bob-foo': wrapInFunc({name: 'foo'}),
             'bob-bar': wrapInFunc({name: 'bar'}),
             'bob-foo-bar': wrapInFunc({name: 'foo-bar'}),
@@ -20,7 +28,7 @@ var autoPlug = (function() {
                 'wrap':   wrapInFunc({name: 'insert.wrap'})
             },
             'bob.baz': wrapInFunc({name: 'baz'}),
-            'findup-sync': function() { return null; }
+            'findup-sync': noFindUp
         });
 })();
 

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,26 @@ describe('auto-plug', function() {
         );
     });
 
+    it('should allow setting the module to get default requireFn from', function() {
+        assert.throws(function() {
+            autoPlug({
+                prefix: 'jack',
+                lazy: false,
+                // use our require, so it will fail loading jack-foo
+                module: module, 
+                config:{'dependencies':{'jack-foo': '*'}}
+            });
+        }, /Cannot find module 'jack-foo'/);
+    });
+
+    it('should allow setting the module to get default config from', function() {
+        var ap =  require('..')({
+            prefix: 'jack', lazy: false, module: autoPlug.module
+        });
+        assert.deepEqual({name: 'jack-foo'}, ap.foo());
+    });
+
+
     it('should throw an error if it can\'t find a package.json', function() {
         assert.throws(function() {
             autoPlug('bob');


### PR DESCRIPTION
As currently written, it's hard to use auto-plug inside another tool that wraps its functionality.  Specifically, you can't tell it what module to use to compute its other defaults, and if you're using lazy loading, the returned object can't be inspected w/e.g. `Object.keys()`.  In addition, the default `require()` comes from auto-plug itself, instead of the requiring module.  (Which e.g. won't load the right version of a module if the requiring module has a different-version dependency in common with auto-plug.)

This pull request addresses all of these issues, by:
- Adding a `module` option that defaults to `module.parent` and is used to compute both the default `requireFn` and `config`, and
- Making lazy-load properties enumerable
- Updating the docs to explain the new defaults
